### PR TITLE
fix(rules): add YAML front matter to all .mdc files for proper display

### DIFF
--- a/.cursor/rules/001_project_overview.mdc
+++ b/.cursor/rules/001_project_overview.mdc
@@ -1,3 +1,10 @@
+---
+title: "Project Overview"
+description: "Overview of the Gmail KB project and its architecture"
+alwaysActive: true
+priority: 10
+---
+
 # MIDS Gmail Knowledge Base RAG Pipeline
 
 ## Project Overview

--- a/.cursor/rules/101_cursor_system_prompt.mdc
+++ b/.cursor/rules/101_cursor_system_prompt.mdc
@@ -1,3 +1,10 @@
+---
+title: "System Prompt"
+description: "Core operating instructions for Cursor AI Agent"
+alwaysActive: true
+priority: 20
+---
+
 # Cursor AI Agent System Prompt
 
 You are an autonomous AI developer operating on a two-file system for project management and execution. Your knowledge and actions are guided exclusively by:

--- a/.cursor/rules/201_project_config_ref.mdc
+++ b/.cursor/rules/201_project_config_ref.mdc
@@ -1,3 +1,10 @@
+---
+title: "Project Configuration"
+description: "Long-term project configuration and technical specifications"
+alwaysActive: true
+priority: 30
+---
+
 # Project Configuration (LTM)
 
 This file contains the stable, long-term context for the project. It is read at the beginning of sessions and referenced when needed for critical decisions.

--- a/.cursor/rules/301_workflow_state.mdc
+++ b/.cursor/rules/301_workflow_state.mdc
@@ -1,3 +1,10 @@
+---
+title: "Workflow State"
+description: "Dynamic workflow state tracking for the Gmail KB project"
+alwaysActive: true
+priority: 40
+---
+
 # Workflow State (STM + Rules + Log)
 
 This file contains the dynamic state of the Supabase Gmail KB project workflow, including current phase, plan, rules, and action log. It is constantly updated during the development process.

--- a/.cursor/rules/401_cursor_tools.mdc
+++ b/.cursor/rules/401_cursor_tools.mdc
@@ -1,3 +1,10 @@
+---
+title: "Cursor MCP Tools"
+description: "Reference guide for all MCP server tools and usage patterns"
+alwaysActive: true
+priority: 50
+---
+
 # Cursor MCP Tools Integration Reference
 
 This document defines all available MCP servers and usage guidelines for this project.

--- a/.cursor/rules/501_git_workflow.mdc
+++ b/.cursor/rules/501_git_workflow.mdc
@@ -1,3 +1,10 @@
+---
+title: "Git Workflow"
+description: "Git and GitHub workflow standards and procedures"
+alwaysActive: true
+priority: 60
+---
+
 # Git Workflow Guidelines
 
 This document defines the Git and GitHub workflow standards for this project.

--- a/.cursor/rules/601_application_flow.mdc
+++ b/.cursor/rules/601_application_flow.mdc
@@ -1,3 +1,10 @@
+---
+title: "Application Flow"
+description: "Complete data flow and architecture of the Gmail KB pipeline"
+alwaysActive: true
+priority: 70
+---
+
 # Application Flow
 
 This document describes the complete data flow of the Gmail Knowledge Base pipeline, including hierarchical data organization using ltree.


### PR DESCRIPTION
This PR fixes the issue with .mdc files not displaying properly in the Cursor MDC file viewer by adding proper YAML front matter to all files.

Changes made:
1. Added YAML front matter to all 7 .mdc files with:
   - `title`: Descriptive title for the file
   - `description`: Brief explanation of the file's purpose
   - `alwaysActive: true`: Ensures files are always visible/active in the viewer
   - `priority`: Numeric value to control display order (10, 20, 30, etc.)

The MDC viewer requires this metadata to properly recognize and render the .mdc files. Without this front matter, the files appear blank in the viewer.

## Summary by Sourcery

Bug Fixes:
- Add required YAML front matter to all `.mdc` files in the `.cursor/rules/` directory.